### PR TITLE
Use snapshot title for url title

### DIFF
--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -12,6 +12,15 @@ class Url < ActiveRecord::Base
   def to_s
     address
   end
+  
+  def title
+    accepted_snapshot = snapshots.where("accepted_at is not null").first
+    if accepted_snapshot.try(:title)
+      accepted_snapshot.title
+    else
+      simplified_url address
+    end
+  end
 
   # @return [Snapshot]
   def baseline(viewport)
@@ -21,4 +30,11 @@ class Url < ActiveRecord::Base
       .where('accepted_at IS NOT NULL')
       .first
   end
+
+  private
+
+  def simplified_url(url)
+    url.gsub(%r[(?:\Ahttp://|/\Z)], '')
+  end
+
 end

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -33,7 +33,7 @@
 
 - @project.urls.each do |url|
   %h2
-    %span.url-multiline= simplified_url url.address
+    %span.url-multiline{ title: url.address }= url.title
     %small
       = link_to snapshots_path(url: url.id), method: :post,
                 title: 'Create new snapshots' do

--- a/app/views/snapshots/_status_block.html.haml
+++ b/app/views/snapshots/_status_block.html.haml
@@ -4,7 +4,7 @@
       %th
         %abbr.initialism{ title: 'Uniform Resource Locator' } URL
       %td
-        = link_to simplified_url(@snapshot.url.address), @snapshot.url.address,
+        = link_to @snapshot.url.title, @snapshot.url.address,
           class: 'url-multiline'
     - if @snapshot.title
       %tr

--- a/spec/models/url_spec.rb
+++ b/spec/models/url_spec.rb
@@ -3,6 +3,40 @@ describe Url do
   let(:url)      { create(:url) }
   let(:viewport) { create(:viewport) }
 
+  describe 'title' do
+    let(:url) { create(:url, address:"http://google.com") }
+    subject   { url.title }
+    it        { should == "google.com" } 
+
+    context 'with a nonaccepted snapshot' do
+      before do
+        create(:snapshot, url: url)
+      end
+
+      it { should == "google.com" }
+    end
+
+    context 'with a accepted snapshot' do
+      let!(:accepted_snapshot) do
+        create(:snapshot, :accepted, url: url)
+      end
+
+      it { should == accepted_snapshot.title }
+    end
+
+    context 'with two accepted snapshots' do
+      let!(:accepted_snapshot1) do
+        create(:snapshot, :accepted, url: url, created_at: Time.now - 5.minutes)
+      end
+      let!(:accepted_snapshot2) do
+        create(:snapshot, :accepted, url: url, created_at: Time.now)
+      end
+
+      it { should == accepted_snapshot2.title }
+    end
+
+  end
+
   describe '#baseline' do
     subject { url.baseline(viewport) }
     it      { should be_nil }


### PR DESCRIPTION
To make url titles readable, we're using the snapshot titles.
Using the title from the last accepted snapshot.
