### PR TITLE
Add animation to sweep progress bars with bootstrap class. Resolves #77.

### DIFF
--- a/app/helpers/sweeps_helper.rb
+++ b/app/helpers/sweeps_helper.rb
@@ -36,7 +36,9 @@ module SweepsHelper
        auto_refresh_type: 'sweep',
        auto_refresh_id:   sweep.id,
      }
-    content_tag(:div, class: 'progress',
+    classes = %w[progress]
+    classes += %w[progress-striped active] if sweep.count_pending > 0
+    content_tag(:div, class: classes,
                       title: sweep_status(sweep),
                       data:  data_attrs) do
       PROGRESS_BAR_STYLE_MAPPINGS.map do |state, bootstrap_class|

--- a/spec/helpers/sweeps_helper_spec.rb
+++ b/spec/helpers/sweeps_helper_spec.rb
@@ -50,4 +50,29 @@ describe SweepsHelper do
       it { should == '3 accepted, 2 rejected' }
     end
   end
+
+  describe '#sweep_progress_bar' do
+   let(:sweep) do
+      build :sweep, count_rejected:     0,
+                    count_pending:      pending,
+                    count_accepted:     0,
+                    count_under_review: 0
+    end
+
+    let(:progress_bar) { Nokogiri::HTML((sweep_progress_bar(sweep))) }
+
+    context 'with pending snapshots' do
+      let(:pending) { 10 }
+      it 'has classes to add animation' do
+        expect((progress_bar.css('div').first)['class']).to eq 'progress progress-striped active'
+      end
+    end
+
+    context 'with all snapshots completed' do
+      let(:pending) { 0 }
+      it 'has classes that only give flat color' do
+        expect((progress_bar.css('div').first)['class']).to eq 'progress'
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'coveralls'
+require 'nokogiri'
 Coveralls.wear!('rails')
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
Summary of changes:
- Changes #sweep_progress_bar view helper by adding different classes to element depending on the number of pending sweeps.  If pending sweeps are 0, (and the sweep is completed), then the class doesn't have animated stripes.
- Adds 2 new specs to check that class is being appropriately applied depending on the number of pending sweeps.
- All specs passing.
