### PR TITLE
Draw only one ChunkyPNG::Image in SnapshotComparer

### DIFF
--- a/app/models/snapshot_comparison_image/after.rb
+++ b/app/models/snapshot_comparison_image/after.rb
@@ -12,7 +12,7 @@ module SnapshotComparisonImage
     # @param row [Diff::LCS:ContextChange]
     def render_added_row(y, row)
       row.new_element.each_with_index do |pixel_after, x|
-        @output.set_pixel(x, y, pixel_after)
+        render_pixel(x, y, pixel_after)
       end
     end
   end

--- a/app/models/snapshot_comparison_image/base.rb
+++ b/app/models/snapshot_comparison_image/base.rb
@@ -15,10 +15,12 @@ module SnapshotComparisonImage
     RED     = ChunkyPNG::Color.from_hex '#dc322f'
     GREEN   = ChunkyPNG::Color.from_hex '#859900'
 
-    # @param width [Integer]
-    # @param height [Integer]
-    def initialize(width, height)
-      @output = ChunkyPNG::Image.new(width, height)
+    # @param offset [Integer] the x-offset that this comparison image should
+    #   use when rendering on the canvas image.
+    # @param canvas [ChunkyPNG::Image] The canvas image to render pixels on.
+    def initialize(offset, canvas)
+      @offset = offset
+      @canvas = canvas
     end
 
     # @param y [Integer]
@@ -40,7 +42,7 @@ module SnapshotComparisonImage
     def render_unchanged_row(y, row)
       row.new_element.each_with_index do |pixel, x|
         # Render the unchanged pixel as-is
-        @output.set_pixel(x, y, pixel)
+        render_pixel(x, y, pixel)
       end
     end
 
@@ -62,11 +64,6 @@ module SnapshotComparisonImage
       # no default implementation
     end
 
-    # @return [ChunkyPNG::Image] the png representation of this image.
-    def to_png
-      @output
-    end
-
     # @param pixel_after [Integer]
     # @param pixel_before [Integer]
     # @return [Float] number between 0 and 1 where 1 is completely different
@@ -85,6 +82,16 @@ module SnapshotComparisonImage
     #   channel of of the difference
     def diff_alpha(diff_score)
       (BASE_DIFF_ALPHA + ((255 - BASE_DIFF_ALPHA) * diff_score)).round
+    end
+
+    # Renders a pixel on the specified x and y position. Uses the offset that
+    # the comparison image has been configured with.
+    #
+    # @param x [Integer]
+    # @param y [Integer]
+    # @param pixel [Integer]
+    def render_pixel(x, y, pixel)
+      @canvas.set_pixel(x + @offset, y, pixel)
     end
   end
 end

--- a/app/models/snapshot_comparison_image/before.rb
+++ b/app/models/snapshot_comparison_image/before.rb
@@ -12,7 +12,7 @@ module SnapshotComparisonImage
     # @param row [Diff::LCS:ContextChange]
     def render_deleted_row(y, row)
       row.old_element.each_with_index do |pixel_before, x|
-        @output.set_pixel(x, y, pixel_before)
+        render_pixel(x, y, pixel_before)
       end
     end
   end

--- a/app/models/snapshot_comparison_image/gutter.rb
+++ b/app/models/snapshot_comparison_image/gutter.rb
@@ -5,17 +5,13 @@ module SnapshotComparisonImage
     WIDTH = 10
     GRAY  = ChunkyPNG::Color.from_hex '#cccccc'
 
-    def initialize(height)
-      super(WIDTH, height)
-    end
-
     def render_row(y, row)
       WIDTH.times do |x|
-        @output.set_pixel(x, y, gutter_color(row))
+        render_pixel(x, y, gutter_color(row))
       end
       # render a two-pixel empty column
       2.times do |x|
-        @output.set_pixel(WIDTH - 1 - x, y, WHITE)
+        render_pixel(WIDTH - 1 - x, y, WHITE)
       end
     end
 

--- a/app/models/snapshot_comparison_image/overlayed.rb
+++ b/app/models/snapshot_comparison_image/overlayed.rb
@@ -5,9 +5,10 @@ module SnapshotComparisonImage
   class Overlayed < SnapshotComparisonImage::Base
     WHITE_OVERLAY = ChunkyPNG::Color.fade(WHITE, 1 - BASE_ALPHA)
 
-    # @param width [Integer]
-    # @param height [Integer]
-    def initialize(width, height)
+    # @param offset [Integer]
+    # @param canvas [ChunkyPNG::Image]
+    # @see SnapshotComparisonImage::Base
+    def initialize(offset, canvas)
       @diff_pixels  = {}
       @faded_pixels = {}
       super
@@ -71,7 +72,7 @@ module SnapshotComparisonImage
     def render_diff_pixel(x, y, score)
       @diff_pixels[score] ||= compose_quick(fade(MAGENTA, diff_alpha(score)),
                                             WHITE)
-      @output.set_pixel(x, y, @diff_pixels[score])
+      render_pixel(x, y, @diff_pixels[score])
     end
 
     # @param x [Integer]
@@ -79,7 +80,7 @@ module SnapshotComparisonImage
     # @param pixel [Integer]
     def render_faded_pixel(x, y, pixel)
       @faded_pixels[pixel] ||= compose_quick(WHITE_OVERLAY, pixel)
-      @output.set_pixel(x, y, @faded_pixels[pixel])
+      render_pixel(x, y, @faded_pixels[pixel])
     end
   end
 end


### PR DESCRIPTION
As pointed out by @lencioni in issue #76, we are spending a lot of time
stitching together the individual images created by the different
`SnapshotComparisonImage`s. This commit changes the implementation of
these classes to reuse the same image canvas for all comparison images,
but use an x-offset to control where on the x-axis the individual images
will start to draw.
