### PR TITLE
Add keyboard shortcuts to jump to top or bottom of page.

### DIFF
--- a/app/assets/javascripts/_keyboard-shortcuts.js
+++ b/app/assets/javascripts/_keyboard-shortcuts.js
@@ -71,21 +71,22 @@ $(function() {
     // Handlers for shortcuts:
 
     function scrollAndFocusTop() {
-      $('html, body').animate({scrollTop: 0}, defaultScrollSpeed);
-      moveFocus({first: true});
+      $('html, body').animate({ scrollTop: 0 }, defaultScrollSpeed);
+      moveFocus({ first: true });
     }
 
     function scrollAndFocusBottom() {
-       $('html, body').animate({scrollTop: $(document).height()}, defaultScrollSpeed);
-       moveFocus({last: true})
+       $('html, body').animate({ scrollTop: $(document).height() },
+          defaultScrollSpeed);
+       moveFocus({ last: true });
     }
 
     function focusNextFocusable() {
-      moveFocus({forward: true});
+      moveFocus({ forward: true });
     }
 
     function focusPreviousFocusable() {
-      moveFocus({backward: true});
+      moveFocus({ backward: true });
     }
 
     function handlePrefixedShortcuts(keyCode) {
@@ -138,14 +139,14 @@ $(function() {
       var $focusable = $('[data-keyboard-focusable]:visible'),
           $focused   = findAndSetFocus(movement, $focusable);
       if ($focused.length) {
-        if (movement.first || movement.last){
+        if (movement.first || movement.last) {
           var $nextFocus = (movement.first) ? $focusable.first() : $focusable.last();
           $focused.removeClass(focusedClass);
           $nextFocus.addClass(focusedClass);
           return true;
         } else {
-          var dir = (movement.forward) ? 1 : -1;
-          var moveTo = $focusable.index($focused) + dir;
+          var dir     = (movement.forward) ? 1 : -1,
+              moveTo  = $focusable.index($focused) + dir;
           if (moveTo >= 0 && moveTo < $focusable.length) {
             $focused.removeClass(focusedClass);
             $focusable.eq(moveTo).addClass(focusedClass);
@@ -179,7 +180,7 @@ $(function() {
     function scrollToFocused() {
       var $focused = $('.' + focusedClass);
       if ($focused.length && !$focused.visible()) {
-        $('html,body').stop(true, true).animate({
+        $('html, body').stop(true, true).animate({
           scrollTop: $focused.offset().top - $(window).height() / 4
         }, defaultScrollSpeed);
       }

--- a/app/views/shared/_keyboard_help_modal.html.haml
+++ b/app/views/shared/_keyboard_help_modal.html.haml
@@ -10,15 +10,15 @@
     ['?', 'Opens this help window'],
     ['k', 'Moves up to the next focusable item on the page'],
     ['j', 'Moves down to the next focusable item on the page'],
+    ['gg', 'Jumps to the top of the page and selects the first focusable item'],
+    ['G', 'Jumps to the bottom of the page and selects the last focusable item'],
     ['o', 'Opens the currently focused item. Also <kbd>&lt;Enter&gt;</kbd>.'],
     ['u', 'Takes you one step up in the page hierarchy'],
     ['a', 'Accepts a snapshot'],
     ['r', 'Rejects a snapshot'],
     ['[', 'Moves to the previous snapshot in a sweep'],
     [']', 'Moves to the next snapshot in a sweep'],
-    ['x', 'Flips between the diff, the before and the after image for a snapshot'],
-    ['gg', 'Jumps to the top of the page and selects the first focusable item'],
-    ['G', 'Jumps to the bottom of the page and selects the last focusable item']
+    ['x', 'Flips between the diff, the before and the after image for a snapshot']
   ]
 .modal.keyboard-shortcut-help{ attributes }
   .modal-dialog


### PR DESCRIPTION
(No specs were added to cover keyboard shortcuts - I can add those and push if you want that done before merging the new shortcuts.)

Fixes #79.

Following the conventions of Vim, 'G' jumps to the bottom of the page
and moves the 'focus' to the last focusable element.
The 'g-g' command jumps to the top of the page, moving the 'focus' to
the first focusable element.

The new shortcuts appear in the 'help modal' with explanations.

Also takes the liberty of alphabetizing the shortcut callbacks.

Issues:
- It would be nice to pull the keyboard shortcut binding out into a
  library, so one could just pass a hash of shortcuts and handlers into
  one method that sets up the right listeners.  Something like this:
  `shortcutsBind({
   '?':  openHelpModal,
  'G':  focusLastFocusable,
  'gg': focusFirstFocusable,
  ...
  })
  `
- Rewrote the `moveFocus` method to handle jumping to first or last
  focusable as well as moving focus forward or backward.  Maybe should
  further decompose into other methods.

Next Steps:
- Write specs for this (feature specs?)
- Add code for the 'gi' shortcut handler.
