### PR TITLE
Fix bug with j shortcut

### DIFF
--- a/app/assets/javascripts/_keyboard-shortcuts.js
+++ b/app/assets/javascripts/_keyboard-shortcuts.js
@@ -106,15 +106,16 @@ $(function() {
       }
     }
 
-    // @param $scope [$Object] jQuery element within which to search for
+    // @param $focusable [$Object] jQuery element within which to search for
     //   focused element(s)
     // @return [$Object] jQuery element that is focused
-    function findAndSetFocus($scope) {
-      var $focused   = $scope.filter('.' + focusedClass);
+    // side effect: if no focused el. is found, it sets the first el. to
+    //   focused.
+    function getFocusedElement($focusable) {
+      var $focused   = $focusable.filter('.' + focusedClass);
       if (!($focused.length)) {
-        var whereToFocus = 'first';
-        setFocus(whereToFocus);
-        $focused   = $scope.filter('.' + focusedClass);
+        setFocus('first');
+        $focused   = $focusable.filter('.' + focusedClass);
       }
       return $focused;
     }
@@ -125,7 +126,7 @@ $(function() {
     function moveFocus(movement) {
       var $focusable  = $('[data-keyboard-focusable]:visible'),
           focusExists = !!($('.' + focusedClass).length),
-          $focused    = findAndSetFocus($focusable);
+          $focused    = getFocusedElement($focusable);
       if (movement.forward && !(focusExists)) {
         // if there was nothing in focus, we stop after moving focus to top
         return


### PR DESCRIPTION
The refactored `move_focus` method first adds focus to the top item if there was none, and then makes the movement called for by the parameter.  That caused a bug where the 'forward' shortcut when pressed on a fresh page would jump to the second focusable item.  This commit adds a condition in the `move_focus` method for when the page is fresh and the movement is forward, stopping it from moving forward the first time the user presses `j`.

For the future, this file could probably be further refactored.
