### PR TITLE
Add 'Diffux' name to the default email 'From' header

### DIFF
--- a/app/mailers/sweep_mailer.rb
+++ b/app/mailers/sweep_mailer.rb
@@ -1,6 +1,6 @@
 # Emails related to Sweeps.
 class SweepMailer < ActionMailer::Base
-  default from: 'no-reply@diffux'
+  default from: 'Diffux <no-reply@diffux>'
 
   def ready_for_review(sweep)
     @sweep = sweep

--- a/spec/mailers/sweep_mailer_spec.rb
+++ b/spec/mailers/sweep_mailer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe SweepMailer do
+  describe '#ready_for_review' do
+    let(:sweep)   { create :sweep }
+    let(:message) { SweepMailer.ready_for_review(sweep) }
+
+    it 'renders a URL to the sweep project' do
+      message.body.encoded.should include project_sweep_url(sweep,
+                                                            project_id: sweep.project)
+    end
+
+    it "sets the sweep's email as the To header" do
+      message[:To].value.should == sweep.email
+    end
+
+    it 'sets a From header containing a name and address' do
+      message[:From].value.should == 'Diffux <no-reply@diffux>'
+    end
+
+    it 'has the right subject' do
+      message.subject.should == "Re: #{sweep.title}"
+    end
+  end
+end


### PR DESCRIPTION
This commit updates the 'From' default email header so that it includes
the name 'Diffux'.

e.g.
  Diffux no-reply@diffux
