### PR TITLE
Use ActiveRecord::Base.find_each in migrations

### DIFF
--- a/db/migrate/20140308175945_add_urls_counter_cache_to_projects.rb
+++ b/db/migrate/20140308175945_add_urls_counter_cache_to_projects.rb
@@ -3,7 +3,7 @@ class AddUrlsCounterCacheToProjects < ActiveRecord::Migration
     add_column :projects, :urls_count, :integer, default: 0
 
     Project.reset_column_information
-    Project.find(:all).each do |p|
+    Project.find_each do |p|
       Project.update_counters p.id, urls_count: p.urls.length
     end
   end

--- a/db/migrate/20140308205112_add_snapshots_counter_cache_to_urls.rb
+++ b/db/migrate/20140308205112_add_snapshots_counter_cache_to_urls.rb
@@ -3,7 +3,7 @@ class AddSnapshotsCounterCacheToUrls < ActiveRecord::Migration
     add_column :urls, :snapshots_count, :integer, default: 0
 
     Url.reset_column_information
-    Url.find(:all).each do |url|
+    Url.find_each do |url|
       Url.update_counters url.id, snapshots_count: url.snapshots.length
     end
   end


### PR DESCRIPTION
ActiveRecord 4.x removed find(:all) in favor of find_each, which
instantiates each record individually instead of all at once.

Fixes #127.